### PR TITLE
use kind 27235 instead of kind 1 for login (from nip98)

### DIFF
--- a/public/js/Room.js
+++ b/public/js/Room.js
@@ -1637,7 +1637,7 @@ async function signSampleEvent(publicKey) {
         // Create an event and sign it to make sure user is who they say they are.
         // also useful if they want to blast a note out to their relays
         const event = {
-            kind: 1,
+            kind: 27235,
             pubkey: publicKey,
             created_at: Math.floor(Date.now() / 1000),
             tags: [],


### PR DESCRIPTION
This will ensure users know the event will not be broadcast as kind1.  Even though it's already an ephemeral event that will not broadcast, the idea that it's kind1 means that it *could be.  With 27235 instead, this is more in line with other nostr app login expectations.