### PR TITLE
Issue 22 - Max Frames Default

### DIFF
--- a/public/js/LocalStorage.js
+++ b/public/js/LocalStorage.js
@@ -38,7 +38,7 @@ class LocalStorage {
             mic_latency: 50, // ms
             mic_volume: 100, // %
             video_fps: 0, // default 1280x768 30fps
-            screen_fps: 3, // default 5fps
+            screen_fps: 0, // default 30fps
             broadcasting: false, // default false (one to many a/v streaming)
             lobby: false, // default false
             pitch_bar: true, // volume indicator


### PR DESCRIPTION
Modified /public/js/LocalStorage.js to change the default choice for Screen FPS in the UI to Max, which is 30 fps