### PR TITLE
Android speaker not working in certain browsers #56

### DIFF
--- a/app/src/scripts/bindable.js
+++ b/app/src/scripts/bindable.js
@@ -22,6 +22,12 @@ const net = require('net');
 */
 
 async function main() {
+    // Adapter script
+    <script src="js/adapter_core.js"></script>
+    const script = document.createElement('script');
+    script.src = 'public/js/adapter.js';
+    document.head.appendChild(script);
+    
     // Server listen
     const serverListenIp = config.server.listen.ip;
     const serverListenPort = config.server.listen.port;

--- a/public/js/adapter.js
+++ b/public/js/adapter.js
@@ -1,17 +1,16 @@
-/*!
- *  Copyright (c) 2014 The WebRTC project authors. All Rights Reserved.
+/*
+ *  Copyright (c) 2016 The WebRTC project authors. All Rights Reserved.
  *
  *  Use of this source code is governed by a BSD-style license
  *  that can be found in the LICENSE file in the root of the source
  *  tree.
  */
+/* eslint-env node */
 
-/* More information about adapter.js can be found at:
- * https://github.com/webrtc/adapter
- */
+'use strict';
 
-(function() {
-  // Adapter.js code goes here.
-  // This is a placeholder for the actual adapter.js code.
-  // You can download the latest version from https://github.com/webrtc/adapter
-})();
+import {adapterFactory} from './adapter_factory.js';
+
+const adapter =
+  adapterFactory({window: typeof window === 'undefined' ? undefined : window});
+export default adapter;

--- a/public/js/adapter.js
+++ b/public/js/adapter.js
@@ -1,0 +1,17 @@
+/*!
+ *  Copyright (c) 2014 The WebRTC project authors. All Rights Reserved.
+ *
+ *  Use of this source code is governed by a BSD-style license
+ *  that can be found in the LICENSE file in the root of the source
+ *  tree.
+ */
+
+/* More information about adapter.js can be found at:
+ * https://github.com/webrtc/adapter
+ */
+
+(function() {
+  // Adapter.js code goes here.
+  // This is a placeholder for the actual adapter.js code.
+  // You can download the latest version from https://github.com/webrtc/adapter
+})();


### PR DESCRIPTION
Probably needs an adapter.js file that handles webrtc compatability issues between browsers. 

Planning to use the [adapter.js](https://github.com/webrtcHacks/adapter) library to handle browser-specific quirks

Thinking the adapter_core.js file should do the trick. 

Added a script to initialize the adapter <script src="js/adapter_core.js"></script>

With that being said, 
I still need to reproduce the issue across multiple browsers to verify the adequacy of the proposed solution.....

Lets Gooo!