### PR TITLE
fix(security): upgrade axios to 1.19.0 — resolves all 10 open Dependabot alerts

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -964,13 +964,13 @@
             "license": "MIT"
         },
         "node_modules/axios": {
-            "version": "1.16.1",
-            "resolved": "https://registry.npmjs.org/axios/-/axios-1.16.1.tgz",
-            "integrity": "sha512-caYkukvroVPO8KrzuJEb50Hm07KwfBZPEC3VeFHTsqWHvKTsy54hjJz9BS/cdaypROE2rH6xvm9mHX4fgWkr3A==",
+            "version": "1.19.0",
+            "resolved": "https://registry.npmjs.org/axios/-/axios-1.19.0.tgz",
+            "integrity": "sha512-ht/iuYZXEjFxLH/Hkezgd7m6JKlHHXEUSneaDz8uZe1Gj5QZtCnpyDsckvAiEnT89OEbCLmnte4R4sn7P0EKFw==",
             "license": "MIT",
             "dependencies": {
                 "follow-redirects": "^1.16.0",
-                "form-data": "^4.0.5",
+                "form-data": "^4.0.6",
                 "https-proxy-agent": "^5.0.1",
                 "proxy-from-env": "^2.1.0"
             }
@@ -3507,9 +3507,9 @@
             "license": "MIT"
         },
         "node_modules/joi": {
-            "version": "17.13.3",
-            "resolved": "https://registry.npmjs.org/joi/-/joi-17.13.3.tgz",
-            "integrity": "sha512-otDA4ldcIx+ZXsKHWmp0YizCweVRZG96J10b0FevjfuncLO1oX59THoAmHkNubYJ+9gWsYsp5k8v4ib6oDv1fA==",
+            "version": "17.13.4",
+            "resolved": "https://registry.npmjs.org/joi/-/joi-17.13.4.tgz",
+            "integrity": "sha512-1RuuER6kmt8K8I3nIWvPZKi5RQCb568ZPyY4Pwjlua+yo+63ZTmIwxLZH0heBmiKN4uxjvCiarDrjaeH84xicQ==",
             "license": "BSD-3-Clause",
             "dependencies": {
                 "@hapi/hoek": "^9.3.0",


### PR DESCRIPTION
## Summary

Resolves **all 10 open Dependabot security alerts** (1 high, 9 medium) plus one joi vulnerability.

### axios 1.16.1 → 1.19.0

| Alert | Severity | Issue |
|-------|----------|-------|
| #120 | **HIGH** | Inherited proxy after interceptor config cloning |
| #129 | medium | Prototype pollution gadgets alter request construction |
| #128 | medium | Nested option objects consume polluted prototype values |
| #126 | medium | Excessive recursion in formDataToJSON (DoS) |
| #125 | medium | Deep formToJSON key recursion (DoS) |
| #124 | medium | Fetch adapter ReadableStream uploads bypass maxBodyLength |
| #119 | medium | Form serializer maxDepth bypass via {} metatoken |
| #118 | medium | HTTP/2 streamed uploads bypass maxBodyLength |
| #117 | medium | NO_PROXY bypass for 0.0.0.0 local addresses |
| #116 | medium | Prototype pollution auth subfields inject Basic auth |

### joi (transitive via express-openid-connect) → 17.13.4
- GHSA-q7cg-457f-vx79: uncaught RangeError on deeply nested input

## Verification
- `npm audit` → **0 vulnerabilities**
- Lockfile-only change; no API breaking changes (axios 1.x semver)

This replaces #166 (dependabot axios PR) which had merge conflicts.